### PR TITLE
Register service annotations before autoconfigure

### DIFF
--- a/src/DependencyInjection/Compiler/ServiceAnnotationPass.php
+++ b/src/DependencyInjection/Compiler/ServiceAnnotationPass.php
@@ -35,16 +35,20 @@ class ServiceAnnotationPass implements CompilerPassInterface
 
         $this->annotationReader = $container->get('annotation_reader');
 
-        $services = array_keys($container->findTaggedServiceIds('terminal42_service_annotation'));
+        foreach ($container->getDefinitions() as $id => $definition) {
+            $class = $definition->getClass();
 
-        /* @var Definition $definition */
-        foreach ($services as $service) {
-            $definition = $container->getDefinition($service);
-            $definition->clearTag('terminal42_service_annotation');
+            if (null === $class && preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)++$/', $id)) {
+                $class = $id;
+            }
 
-            $reflection = new \ReflectionClass($definition->getClass());
+            $class = $container->getParameterBag()->resolveValue($class);
 
-            if ($reflection->isAbstract()) {
+            if (
+                !$class
+                || null === ($reflection = $container->getReflectionClass($class, false))
+                || $reflection->isAbstract()
+            ) {
                 continue;
             }
 

--- a/src/DependencyInjection/Compiler/ServiceAnnotationPass.php
+++ b/src/DependencyInjection/Compiler/ServiceAnnotationPass.php
@@ -38,6 +38,8 @@ class ServiceAnnotationPass implements CompilerPassInterface
         foreach ($container->getDefinitions() as $id => $definition) {
             $class = $definition->getClass();
 
+            // See Symfony\Component\DependencyInjection\Compiler\ResolveClassPass
+            // Needs to be done here because this compiler pass runs before ResolveClassPass
             if (null === $class && preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)++$/', $id)) {
                 $class = $id;
             }

--- a/src/ServiceAnnotationInterface.php
+++ b/src/ServiceAnnotationInterface.php
@@ -13,9 +13,8 @@ namespace Terminal42\ServiceAnnotationBundle;
 
 /**
  * Marker interface for Symfony service auto configuration.
- * No longer needed as of Version 1.1.
  *
- * @deprecated
+ * @deprecated No longer needed as of Version 1.1.
  */
 interface ServiceAnnotationInterface
 {

--- a/src/ServiceAnnotationInterface.php
+++ b/src/ServiceAnnotationInterface.php
@@ -13,6 +13,9 @@ namespace Terminal42\ServiceAnnotationBundle;
 
 /**
  * Marker interface for Symfony service auto configuration.
+ * No longer needed as of Version 1.1.
+ *
+ * @deprecated
  */
 interface ServiceAnnotationInterface
 {

--- a/src/Terminal42ServiceAnnotationBundle.php
+++ b/src/Terminal42ServiceAnnotationBundle.php
@@ -22,11 +22,6 @@ class Terminal42ServiceAnnotationBundle extends Bundle
     {
         parent::build($container);
 
-        $container
-            ->registerForAutoconfiguration(ServiceAnnotationInterface::class)
-            ->addTag('terminal42_service_annotation')
-        ;
-
-        $container->addCompilerPass(new ServiceAnnotationPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 99);
+        $container->addCompilerPass(new ServiceAnnotationPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 110);
     }
 }

--- a/src/Terminal42ServiceAnnotationBundle.php
+++ b/src/Terminal42ServiceAnnotationBundle.php
@@ -22,6 +22,9 @@ class Terminal42ServiceAnnotationBundle extends Bundle
     {
         parent::build($container);
 
+        // Priority must be higher than ResolveInstanceofConditionalsPass so annotations
+        // are added before autoconfiguration adds tags for interfaces etc.
+        // See Symfony\Component\DependencyInjection\Compiler\PassConfig
         $container->addCompilerPass(new ServiceAnnotationPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 110);
     }
 }


### PR DESCRIPTION
I realized there is a problem with the current implementation of service tagging: If autoconfiguration is enabled for an interface, Symfony will tag classes of that interface automatically in the container. Because our composer pass runs _after_ Symfony, the annotated tag is added _after_ the "default" one, which means the default one will likely win.

Changing this obviously changes the behavior, but imho this change is the right thing because of 2 reasons:
 1. the tag will be added to the service before `autoconfigure`, which means the behavior is the same as if the service is tagged in the configuration file.
 2. we no longer need to tag a service or use autoconfigure and an interface for the annotations to work. Simply add an annotation to your file and you're good 🎉 

What do you think @Toflar @leofeyer @ausi @fritzmg ?