### PR TITLE
Allow Symfony 6.x packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "doctrine/annotations": "^1.6",
-        "symfony/dependency-injection": "^4.0 || ^5.0",
-        "symfony/http-kernel": "^4.0 || ^5.0"
+        "symfony/dependency-injection": "^4.0 || ^5.0 || ^6.0",
+        "symfony/http-kernel": "^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "contao/easy-coding-standard": "^3.0"


### PR DESCRIPTION
When trying to install Contao 5.0.0-RC2 with Symfony 6.x

```
    - terminal42/service-annotation-bundle[1.1.0, ..., 1.1.2] require php ^7.1 -> your php version (8.1.9) does not satisfy that requirement.
    - terminal42/service-annotation-bundle 1.1.3 requires symfony/dependency-injection ^4.0 || ^5.0 -> found symfony/dependency-injection[v4.0.0, ..., v4.4.44, v5.0.0, ..., v5.4.11] but it conflicts with your root composer.json require (^6.0).
    - contao/core-bundle 5.0.0-RC2 requires terminal42/service-annotation-bundle ^1.1 -> satisfiable by terminal42/service-annotation-bundle[1.1.0, 1.1.1, 1.1.2, 1.1.3].
    - Root composer.json requires contao/core-bundle ^5.0.0-RC2 -> satisfiable by contao/core-bundle[5.0.0-RC2].
```