### PR TITLE
Allow doctrine/annotations v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^7.1 || ^8.0",
-        "doctrine/annotations": "^1.6",
+        "doctrine/annotations": "^1.6 || ^2.0",
         "symfony/dependency-injection": "^4.0 || ^5.0 || ^6.0",
         "symfony/http-kernel": "^4.0 || ^5.0 || ^6.0"
     },


### PR DESCRIPTION
I've manually tested - the components we're using are still there and unchanged.

We need this because some libraries require `doctrine/annotations` `v2` ([e.g. PHP CS-Fixer 3.15+](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/commit/1b2e3a3d17d0d03bf0a4132e3a0feaf2035355ac)) and this bundle is still used for Contao 4.13 LTS for example.