### PR TITLE
Catch exceptions when resolving classes

### DIFF
--- a/src/DependencyInjection/Compiler/ServiceAnnotationPass.php
+++ b/src/DependencyInjection/Compiler/ServiceAnnotationPass.php
@@ -37,7 +37,13 @@ class ServiceAnnotationPass implements CompilerPassInterface
                 $class = $id;
             }
 
-            $class = $container->getParameterBag()->resolveValue($class);
+            try {
+                $class = $container->getParameterBag()->resolveValue($class);
+            } catch (\Throwable $exception) {
+                // This is not processable - potentially problem with other bundles that register services with parameters as class name.
+                // The parameter might not be available yet, as we are registered with priority 110.
+                continue;
+            }
 
             if (
                 !$class


### PR DESCRIPTION
When any service (in my case provided by hwi-oauth-bundle) has a parameterized class (`%foo.bar.baz%`) this bundle here crashes hard and makes the application unusable. This stems from the fact, that the parameter value is not available during compile time that early (this compiler pass runs with priority 110). We now silently skip over all services that have a non-resolvable class name.